### PR TITLE
IS-2061: Add V3 endpoints. Only expose one VeilederDTO object.

### DIFF
--- a/src/main/kotlin/no/nav/syfo/application/api/ApiModule.kt
+++ b/src/main/kotlin/no/nav/syfo/application/api/ApiModule.kt
@@ -12,6 +12,7 @@ import no.nav.syfo.client.azuread.AzureAdClient
 import no.nav.syfo.client.graphapi.GraphApiClient
 import no.nav.syfo.client.wellknown.WellKnown
 import no.nav.syfo.veileder.api.registrerVeiledereApi
+import no.nav.syfo.veileder.api.registrerVeiledereApiV3
 import no.nav.syfo.veileder.api.registrerVeilederinfoApi
 import no.nav.syfo.veiledernavn.VeilederService
 
@@ -71,6 +72,7 @@ fun Application.apiModule(
             registrerVeiledereApi(
                 veilederService = veilederService,
             )
+            registrerVeiledereApiV3(veilederService = veilederService)
         }
     }
 }

--- a/src/main/kotlin/no/nav/syfo/application/cache/RedisStore.kt
+++ b/src/main/kotlin/no/nav/syfo/application/cache/RedisStore.kt
@@ -1,10 +1,12 @@
 package no.nav.syfo.application.cache
 
+import com.fasterxml.jackson.databind.exc.MismatchedInputException
 import no.nav.syfo.util.configuredJacksonMapper
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import redis.clients.jedis.JedisPool
 import redis.clients.jedis.exceptions.JedisConnectionException
+import java.lang.Exception
 
 class RedisStore(private val jedisPool: JedisPool) {
 
@@ -35,6 +37,12 @@ class RedisStore(private val jedisPool: JedisPool) {
             jedisPool.resource.use { jedis -> return jedis.get(key) }
         } catch (e: JedisConnectionException) {
             log.warn("Got connection error when fetching from redis! Continuing without cached value", e)
+            return null
+        } catch (e: MismatchedInputException) {
+            log.error("Got deserialization error when fetching from redis! Continuing without cached value", e)
+            return null
+        } catch (e: Exception) {
+            log.error("Got error when fetching from redis! Continuing without cached value", e)
             return null
         }
     }

--- a/src/main/kotlin/no/nav/syfo/client/axsys/AxsysVeileder.kt
+++ b/src/main/kotlin/no/nav/syfo/client/axsys/AxsysVeileder.kt
@@ -1,15 +1,17 @@
 package no.nav.syfo.client.axsys
 
-import no.nav.syfo.veileder.Veileder
+import no.nav.syfo.veileder.VeilederInfo
 
 data class AxsysVeileder(
     val appIdent: String,
     val historiskIdent: Number,
 )
 
-fun AxsysVeileder.toVeileder() =
-    Veileder(
+fun AxsysVeileder.toVeilederInfo() =
+    VeilederInfo(
+        ident = appIdent,
         fornavn = "",
         etternavn = "",
-        ident = appIdent,
+        epost = "",
+        telefonnummer = "",
     )

--- a/src/main/kotlin/no/nav/syfo/client/graphapi/BatchResponse.kt
+++ b/src/main/kotlin/no/nav/syfo/client/graphapi/BatchResponse.kt
@@ -1,7 +1,5 @@
 package no.nav.syfo.client.graphapi
 
-import no.nav.syfo.veileder.Veileder
-
 data class GraphBatchRequest(
     val requests: List<RequestEntry>,
 )
@@ -23,18 +21,5 @@ data class BatchBody(
 )
 
 data class GetUsersResponse(
-    val value: List<AADVeileder>,
+    val value: List<GraphApiUser>,
 )
-
-data class AADVeileder(
-    val givenName: String,
-    val surname: String,
-    val onPremisesSamAccountName: String,
-)
-
-fun AADVeileder.toVeileder() =
-    Veileder(
-        fornavn = givenName,
-        etternavn = surname,
-        ident = onPremisesSamAccountName,
-    )

--- a/src/main/kotlin/no/nav/syfo/client/graphapi/GraphApiClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/graphapi/GraphApiClient.kt
@@ -137,7 +137,7 @@ class GraphApiClient(
 
     companion object {
         const val GRAPH_API_CACHE_VEILEDER_PREFIX = "graphapiVeileder-"
-        const val GRAPH_API_CACHE_VEILEDER_LISTE_PREFIX = "graphapiVeilederListe-"
+        const val GRAPH_API_CACHE_VEILEDER_LISTE_PREFIX = "graphapiVeiledereFraEnhet-"
         private val log = LoggerFactory.getLogger(GraphApiClient::class.java)
     }
 }

--- a/src/main/kotlin/no/nav/syfo/client/graphapi/GraphApiClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/graphapi/GraphApiClient.kt
@@ -77,7 +77,7 @@ class GraphApiClient(
         callId: String,
         token: String,
     ): List<GraphApiUser> {
-        val cacheKey = "$GRAPH_API_CACHE_VEILEDER_LISTE_PREFIX$enhetNr"
+        val cacheKey = "$GRAPH_API_CACHE_VEILEDERE_FRA_ENHET_PREFIX$enhetNr"
         val cachedObject: List<GraphApiUser>? = cache.getListObject(cacheKey)
         return if (cachedObject != null) {
             COUNT_CALL_GRAPHAPI_VEILEDER_LIST_CACHE_HIT.increment()
@@ -137,7 +137,7 @@ class GraphApiClient(
 
     companion object {
         const val GRAPH_API_CACHE_VEILEDER_PREFIX = "graphapiVeileder-"
-        const val GRAPH_API_CACHE_VEILEDER_LISTE_PREFIX = "graphapiVeiledereFraEnhet-"
+        const val GRAPH_API_CACHE_VEILEDERE_FRA_ENHET_PREFIX = "graphapiVeiledereFraEnhet-"
         private val log = LoggerFactory.getLogger(GraphApiClient::class.java)
     }
 }

--- a/src/main/kotlin/no/nav/syfo/veileder/Veileder.kt
+++ b/src/main/kotlin/no/nav/syfo/veileder/Veileder.kt
@@ -6,7 +6,16 @@ data class Veileder(
     val ident: String,
     val fornavn: String?,
     val etternavn: String?,
-)
+) {
+    companion object {
+        fun fromVeilederInfo(veilederInfo: VeilederInfo): Veileder =
+            Veileder(
+                ident = veilederInfo.ident,
+                fornavn = veilederInfo.fornavn,
+                etternavn = veilederInfo.etternavn,
+            )
+    }
+}
 
 fun List<Veileder>.toVeilederDTOList() = this.map {
     it.toVeilederDTO()

--- a/src/main/kotlin/no/nav/syfo/veileder/api/VeiledereApi.kt
+++ b/src/main/kotlin/no/nav/syfo/veileder/api/VeiledereApi.kt
@@ -1,11 +1,12 @@
 package no.nav.syfo.veileder.api
 
-import io.ktor.server.application.*
 import io.ktor.http.*
+import io.ktor.server.application.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import no.nav.syfo.util.getBearerHeader
 import no.nav.syfo.util.getCallId
+import no.nav.syfo.veileder.Veileder
 import no.nav.syfo.veileder.toVeilederDTOList
 import no.nav.syfo.veiledernavn.VeilederService
 import org.slf4j.Logger
@@ -34,8 +35,8 @@ fun Route.registrerVeiledereApi(
                     callId = callId,
                     enhetNr = enhetNr,
                     token = token,
-                ).toVeilederDTOList()
-                call.respond(veilederList)
+                ).map { Veileder.fromVeilederInfo(it) }.toVeilederDTOList()
+                call.respond<List<VeilederDTO>>(veilederList)
             } catch (e: IllegalArgumentException) {
                 val illegalArgumentMessage = "Could not retrieve VeilederList for enhetNr:"
                 log.warn("$illegalArgumentMessage: {}, {}", e.message, callId)

--- a/src/main/kotlin/no/nav/syfo/veileder/api/VeiledereApiV3.kt
+++ b/src/main/kotlin/no/nav/syfo/veileder/api/VeiledereApiV3.kt
@@ -1,0 +1,69 @@
+package no.nav.syfo.veileder.api
+
+import io.ktor.http.*
+import io.ktor.server.application.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import no.nav.syfo.util.getBearerHeader
+import no.nav.syfo.util.getCallId
+import no.nav.syfo.veileder.*
+import no.nav.syfo.veiledernavn.VeilederService
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+private val log: Logger = LoggerFactory.getLogger("no.nav.syfo")
+
+const val basePath = "/syfoveileder/api/v3"
+
+fun Route.registrerVeiledereApiV3(
+    veilederService: VeilederService,
+) {
+    route(basePath) {
+        get("/veiledere") {
+            val callId = getCallId()
+            val enhetNr = call.request.queryParameters["enhetNr"]
+                ?: throw IllegalArgumentException("No EnhetNr found in query param")
+            try {
+                val token = getBearerHeader()
+                    ?: throw IllegalArgumentException("No Authorization header supplied")
+
+                val veilederList = veilederService.getVeiledere(
+                    callId = callId,
+                    enhetNr = enhetNr,
+                    token = token,
+                )
+                call.respond<List<VeilederInfo>>(veilederList)
+            } catch (e: IllegalArgumentException) {
+                val illegalArgumentMessage = "Could not retrieve VeilederList for enhetNr:"
+                log.warn("$illegalArgumentMessage: {}, {}", e.message, callId)
+                call.respond(HttpStatusCode.BadRequest, e.message ?: illegalArgumentMessage)
+            }
+        }
+
+        get("/veiledere/{navIdent}") {
+            val callId = getCallId()
+            try {
+                val token = getBearerHeader()
+                    ?: throw IllegalArgumentException("No Authorization header supplied")
+
+                val veilederIdent = call.parameters["navIdent"]
+                    ?: throw IllegalArgumentException("No VeilederIdent found in path param")
+
+                val veilederinfo = veilederService.veilederInfo(
+                    callId = callId,
+                    veilederIdent = veilederIdent,
+                    token = token,
+                )
+                call.respond<VeilederInfo>(veilederinfo)
+            } catch (e: IllegalArgumentException) {
+                val illegalArgumentMessage = "Could not retrieve Veilederinfo for NavIdent"
+                log.warn("$illegalArgumentMessage: {}, {}", e.message, callId)
+                call.respond(HttpStatusCode.BadRequest, e.message ?: illegalArgumentMessage)
+            } catch (e: GraphApiException) {
+                val warningMessage = "Could not retrieve Veilederinfo for NavIdent"
+                log.warn("$warningMessage: {}, {}", e.message, callId)
+                call.respond(HttpStatusCode.InternalServerError, e.message ?: warningMessage)
+            }
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/veiledernavn/VeilederService.kt
+++ b/src/main/kotlin/no/nav/syfo/veiledernavn/VeilederService.kt
@@ -28,24 +28,24 @@ class VeilederService(
         callId: String,
         enhetNr: String,
         token: String,
-    ): List<Veileder> {
+    ): List<VeilederInfo> {
         val axsysVeilederList = axsysClient.veilederList(
             callId = callId,
             enhetNr = enhetNr,
             token = token,
         )
-        val graphApiVeiledere = graphApiClient.veilederList(
+        val veiledere = graphApiClient.veilederList(
             enhetNr = enhetNr,
             axsysVeilederlist = axsysVeilederList,
             callId = callId,
             token = token,
-        )
+        ).map { it.toVeilederInfo(it.onPremisesSamAccountName) }
 
         val missingInGraphAPI = mutableListOf<String>()
-        val returnList = axsysVeilederList.map { axsysVeileder ->
-            graphApiVeiledere.find { it.ident == axsysVeileder.appIdent } ?: noGraphApiVeileder(
+        val returnList: List<VeilederInfo> = axsysVeilederList.map { axsysVeileder ->
+            veiledere.find { it.ident == axsysVeileder.appIdent } ?: noGraphApiVeileder(
                 axsysVeileder,
-                missingInGraphAPI
+                missingInGraphAPI,
             )
         }
         if (missingInGraphAPI.isNotEmpty()) {
@@ -57,9 +57,9 @@ class VeilederService(
     fun noGraphApiVeileder(
         axsysVeileder: AxsysVeileder,
         missingInGraphAPI: MutableList<String>,
-    ): Veileder {
+    ): VeilederInfo {
         missingInGraphAPI.add(axsysVeileder.appIdent)
-        return axsysVeileder.toVeileder()
+        return axsysVeileder.toVeilederInfo()
     }
 
     companion object {

--- a/src/test/kotlin/no/nav/syfo/testhelper/mock/GraphApiMock.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/mock/GraphApiMock.kt
@@ -35,10 +35,12 @@ fun generateGraphapiUserListResponse() =
                 id = "1",
                 body = GetUsersResponse(
                     value = listOf(
-                        AADVeileder(
+                        GraphApiUser(
                             givenName = "Given",
                             surname = "Surname",
                             onPremisesSamAccountName = VEILEDER_IDENT,
+                            mail = "give.surname@nav.no",
+                            businessPhones = emptyList(),
                         ),
                     ),
                 ),

--- a/src/test/kotlin/no/nav/syfo/veileder/api/VeiledereApiV3Spek.kt
+++ b/src/test/kotlin/no/nav/syfo/veileder/api/VeiledereApiV3Spek.kt
@@ -1,0 +1,134 @@
+package no.nav.syfo.veileder.api
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import io.ktor.http.*
+import io.ktor.server.testing.*
+import no.nav.syfo.client.axsys.AxsysClient
+import no.nav.syfo.client.axsys.AxsysVeileder
+import no.nav.syfo.testhelper.*
+import no.nav.syfo.util.bearerHeader
+import no.nav.syfo.util.configuredJacksonMapper
+import no.nav.syfo.veileder.VeilederInfo
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldNotBeEqualTo
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+class VeiledereApiV3Spek : Spek({
+    val objectMapper: ObjectMapper = configuredJacksonMapper()
+
+    val basePath = "/syfoveileder/api/v3/veiledere"
+
+    describe(VeiledereApiV3Spek::class.java.simpleName) {
+
+        with(TestApplicationEngine()) {
+            start()
+
+            val externalMockEnvironment = ExternalMockEnvironment()
+
+            beforeGroup {
+                externalMockEnvironment.startExternalMocks()
+            }
+
+            afterGroup {
+                externalMockEnvironment.stopExternalMocks()
+            }
+
+            application.testApiModule(
+                externalMockEnvironment = externalMockEnvironment,
+            )
+
+            describe("Get list of Veiledere for enhetNr") {
+                val urlVeiledereEnhetNr = "$basePath?enhetNr=${UserConstants.ENHET_NR}"
+
+                val validTokenVeileder = generateJWT(
+                    audience = externalMockEnvironment.environment.azureAppClientId,
+                    issuer = externalMockEnvironment.wellKnownInternalAzureAD.issuer,
+                    navIdent = UserConstants.VEILEDER_IDENT,
+                )
+
+                describe("Happy path") {
+
+                    val axsysResponse = externalMockEnvironment.axsysMock.axsysResponse
+
+                    val graphapiUserResponse = externalMockEnvironment.graphApiMock.graphapiUserResponse.value.first()
+                    val redisCache = externalMockEnvironment.redisCache
+                    val cacheKey = "${AxsysClient.AXSYS_CACHE_KEY_PREFIX}${UserConstants.ENHET_NR}"
+
+                    it("should return OK if request is successful and veilederlist should be cached") {
+                        redisCache.getListObject<AxsysVeileder>(cacheKey) shouldBeEqualTo null
+                        with(
+                            handleRequest(HttpMethod.Get, urlVeiledereEnhetNr) {
+                                addHeader(HttpHeaders.Authorization, bearerHeader(validTokenVeileder))
+                            }
+                        ) {
+                            response.status() shouldBeEqualTo HttpStatusCode.OK
+                            val veilederInfoList = objectMapper.readValue<List<VeilederInfo>>(response.content!!)
+
+                            veilederInfoList.size shouldBeEqualTo axsysResponse.size
+
+                            veilederInfoList.first().ident shouldBeEqualTo axsysResponse.first().appIdent
+                            veilederInfoList.first().fornavn shouldBeEqualTo graphapiUserResponse.givenName
+                            veilederInfoList.first().etternavn shouldBeEqualTo graphapiUserResponse.surname
+
+                            veilederInfoList.last().ident shouldBeEqualTo axsysResponse.last().appIdent
+                            veilederInfoList.last().fornavn shouldBeEqualTo ""
+                            veilederInfoList.last().etternavn shouldBeEqualTo ""
+                            redisCache.getListObject<AxsysVeileder>(cacheKey) shouldNotBeEqualTo null
+                        }
+                    }
+                }
+                describe("Unhappy paths") {
+                    it("should return status Unauthorized if no token is supplied") {
+                        with(
+                            handleRequest(HttpMethod.Get, urlVeiledereEnhetNr) {}
+                        ) {
+                            response.status() shouldBeEqualTo HttpStatusCode.Unauthorized
+                        }
+                    }
+                }
+            }
+
+            describe("Get Veilederinfo for veileder ident") {
+                val urlVeilederinfoNotSelf = "$basePath/${UserConstants.VEILEDER_IDENT}"
+
+                val validTokenVeileder2 = generateJWT(
+                    audience = externalMockEnvironment.environment.azureAppClientId,
+                    issuer = externalMockEnvironment.wellKnownInternalAzureAD.issuer,
+                    navIdent = UserConstants.VEILEDER_IDENT_2,
+                )
+
+                describe("Happy path") {
+
+                    val graphapiUserResponse = externalMockEnvironment.graphApiMock.graphapiUserResponse.value[0]
+
+                    it("should return OK if request is successful") {
+                        with(
+                            handleRequest(HttpMethod.Get, urlVeilederinfoNotSelf) {
+                                addHeader(HttpHeaders.Authorization, bearerHeader(validTokenVeileder2))
+                            }
+                        ) {
+                            response.status() shouldBeEqualTo HttpStatusCode.OK
+                            val veilederInfoDTO = objectMapper.readValue<VeilederInfo>(response.content!!)
+
+                            veilederInfoDTO.ident shouldBeEqualTo UserConstants.VEILEDER_IDENT
+                            veilederInfoDTO.fornavn shouldBeEqualTo graphapiUserResponse.givenName
+                            veilederInfoDTO.etternavn shouldBeEqualTo graphapiUserResponse.surname
+                            veilederInfoDTO.epost shouldBeEqualTo graphapiUserResponse.mail
+                        }
+                    }
+                }
+                describe("Unhappy paths") {
+                    it("should return status Unauthorized if no token is supplied") {
+                        with(
+                            handleRequest(HttpMethod.Get, urlVeilederinfoNotSelf) {}
+                        ) {
+                            response.status() shouldBeEqualTo HttpStatusCode.Unauthorized
+                        }
+                    }
+                }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/no/nav/syfo/veileder/api/VeiledereApiV3Spek.kt
+++ b/src/test/kotlin/no/nav/syfo/veileder/api/VeiledereApiV3Spek.kt
@@ -6,6 +6,8 @@ import io.ktor.http.*
 import io.ktor.server.testing.*
 import no.nav.syfo.client.axsys.AxsysClient
 import no.nav.syfo.client.axsys.AxsysVeileder
+import no.nav.syfo.client.graphapi.GraphApiClient
+import no.nav.syfo.client.graphapi.GraphApiUser
 import no.nav.syfo.testhelper.*
 import no.nav.syfo.util.bearerHeader
 import no.nav.syfo.util.configuredJacksonMapper
@@ -38,6 +40,90 @@ class VeiledereApiV3Spek : Spek({
             application.testApiModule(
                 externalMockEnvironment = externalMockEnvironment,
             )
+
+            describe("Get Veilederinfo for self") {
+                val urlVeilederinfoSelf = "$basePath/self"
+
+                val validTokenVeileder1 = generateJWT(
+                    audience = externalMockEnvironment.environment.azureAppClientId,
+                    issuer = externalMockEnvironment.wellKnownInternalAzureAD.issuer,
+                    navIdent = UserConstants.VEILEDER_IDENT,
+                )
+
+                describe("Happy path") {
+
+                    val graphapiUserResponse = externalMockEnvironment.graphApiMock.graphapiUserResponse.value[0]
+                    val redisCache = externalMockEnvironment.redisCache
+                    val cacheKey = "${GraphApiClient.GRAPH_API_CACHE_VEILEDER_PREFIX}${UserConstants.VEILEDER_IDENT}"
+
+                    it("should return OK if request is successful and graphapi response should be cached") {
+                        redisCache.getObject<GraphApiUser>(cacheKey) shouldBeEqualTo null
+                        with(
+                            handleRequest(HttpMethod.Get, urlVeilederinfoSelf) {
+                                addHeader(HttpHeaders.Authorization, bearerHeader(validTokenVeileder1))
+                            }
+                        ) {
+                            response.status() shouldBeEqualTo HttpStatusCode.OK
+                            val veilederInfo = objectMapper.readValue<VeilederInfo>(response.content!!)
+
+                            veilederInfo.ident shouldBeEqualTo UserConstants.VEILEDER_IDENT
+                            veilederInfo.fornavn shouldBeEqualTo graphapiUserResponse.givenName
+                            veilederInfo.etternavn shouldBeEqualTo graphapiUserResponse.surname
+                            veilederInfo.epost shouldBeEqualTo graphapiUserResponse.mail
+                            redisCache.getObject<GraphApiUser>(cacheKey) shouldNotBeEqualTo null
+                        }
+                    }
+                }
+                describe("Unhappy paths") {
+                    it("should return status Unauthorized if no token is supplied") {
+                        with(
+                            handleRequest(HttpMethod.Get, urlVeilederinfoSelf) {}
+                        ) {
+                            response.status() shouldBeEqualTo HttpStatusCode.Unauthorized
+                        }
+                    }
+                }
+            }
+
+            describe("Get Veilederinfo for veileder ident") {
+                val urlVeilederinfoNotSelf = "$basePath/${UserConstants.VEILEDER_IDENT}"
+
+                val validTokenVeileder2 = generateJWT(
+                    audience = externalMockEnvironment.environment.azureAppClientId,
+                    issuer = externalMockEnvironment.wellKnownInternalAzureAD.issuer,
+                    navIdent = UserConstants.VEILEDER_IDENT_2,
+                )
+
+                describe("Happy path") {
+
+                    val graphapiUserResponse = externalMockEnvironment.graphApiMock.graphapiUserResponse.value[0]
+
+                    it("should return OK if request is successful") {
+                        with(
+                            handleRequest(HttpMethod.Get, urlVeilederinfoNotSelf) {
+                                addHeader(HttpHeaders.Authorization, bearerHeader(validTokenVeileder2))
+                            }
+                        ) {
+                            response.status() shouldBeEqualTo HttpStatusCode.OK
+                            val veilederInfoDTO = objectMapper.readValue<VeilederInfo>(response.content!!)
+
+                            veilederInfoDTO.ident shouldBeEqualTo UserConstants.VEILEDER_IDENT
+                            veilederInfoDTO.fornavn shouldBeEqualTo graphapiUserResponse.givenName
+                            veilederInfoDTO.etternavn shouldBeEqualTo graphapiUserResponse.surname
+                            veilederInfoDTO.epost shouldBeEqualTo graphapiUserResponse.mail
+                        }
+                    }
+                }
+                describe("Unhappy paths") {
+                    it("should return status Unauthorized if no token is supplied") {
+                        with(
+                            handleRequest(HttpMethod.Get, urlVeilederinfoNotSelf) {}
+                        ) {
+                            response.status() shouldBeEqualTo HttpStatusCode.Unauthorized
+                        }
+                    }
+                }
+            }
 
             describe("Get list of Veiledere for enhetNr") {
                 val urlVeiledereEnhetNr = "$basePath?enhetNr=${UserConstants.ENHET_NR}"
@@ -83,46 +169,6 @@ class VeiledereApiV3Spek : Spek({
                     it("should return status Unauthorized if no token is supplied") {
                         with(
                             handleRequest(HttpMethod.Get, urlVeiledereEnhetNr) {}
-                        ) {
-                            response.status() shouldBeEqualTo HttpStatusCode.Unauthorized
-                        }
-                    }
-                }
-            }
-
-            describe("Get Veilederinfo for veileder ident") {
-                val urlVeilederinfoNotSelf = "$basePath/${UserConstants.VEILEDER_IDENT}"
-
-                val validTokenVeileder2 = generateJWT(
-                    audience = externalMockEnvironment.environment.azureAppClientId,
-                    issuer = externalMockEnvironment.wellKnownInternalAzureAD.issuer,
-                    navIdent = UserConstants.VEILEDER_IDENT_2,
-                )
-
-                describe("Happy path") {
-
-                    val graphapiUserResponse = externalMockEnvironment.graphApiMock.graphapiUserResponse.value[0]
-
-                    it("should return OK if request is successful") {
-                        with(
-                            handleRequest(HttpMethod.Get, urlVeilederinfoNotSelf) {
-                                addHeader(HttpHeaders.Authorization, bearerHeader(validTokenVeileder2))
-                            }
-                        ) {
-                            response.status() shouldBeEqualTo HttpStatusCode.OK
-                            val veilederInfoDTO = objectMapper.readValue<VeilederInfo>(response.content!!)
-
-                            veilederInfoDTO.ident shouldBeEqualTo UserConstants.VEILEDER_IDENT
-                            veilederInfoDTO.fornavn shouldBeEqualTo graphapiUserResponse.givenName
-                            veilederInfoDTO.etternavn shouldBeEqualTo graphapiUserResponse.surname
-                            veilederInfoDTO.epost shouldBeEqualTo graphapiUserResponse.mail
-                        }
-                    }
-                }
-                describe("Unhappy paths") {
-                    it("should return status Unauthorized if no token is supplied") {
-                        with(
-                            handleRequest(HttpMethod.Get, urlVeilederinfoNotSelf) {}
                         ) {
                             response.status() shouldBeEqualTo HttpStatusCode.Unauthorized
                         }


### PR DESCRIPTION
Endrer cache key for kallet som feilet sist, slik at [samme problem](https://logs.adeo.no/app/discover#/view/a90cb590-5515-11ed-b3e8-d969437dd878?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:'2024-03-06T10:38:08.427Z',to:'2024-03-06T12:53:44.659Z'))&_a=(columns:!(message,envclass,level,application,host),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'96e648c0-980a-11e9-830a-e17bbd64b4db',key:envclass,negate:!f,params:(query:p),type:phrase),query:(match_phrase:(envclass:p))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'96e648c0-980a-11e9-830a-e17bbd64b4db',key:level,negate:!f,params:(query:Error),type:phrase),query:(match_phrase:(level:Error))),('$state':(store:appState),meta:(alias:!n,disabled:!f,field:team,index:'96e648c0-980a-11e9-830a-e17bbd64b4db',key:team,negate:!f,params:(query:teamsykefravr),type:phrase),query:(match_phrase:(team:teamsykefravr))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'96e648c0-980a-11e9-830a-e17bbd64b4db',key:application,negate:!f,params:(query:syfoveileder),type:phrase),query:(match_phrase:(application:syfoveileder)))),hideChart:!f,index:'96e648c0-980a-11e9-830a-e17bbd64b4db',interval:auto,query:(language:lucene,query:''),sort:!(!('@timestamp',desc)))) ikke skal oppstå.
Sist så lå det data i cachen på et utdatert format, slik at uthenting feilet. Når vi nå endrer cache key vil den gamle cache keyen bli utdatert i løpet av en time.

[Se PR som var utgangspunktet](https://github.com/navikt/syfoveileder/pull/82) for denne