### PR TITLE
Log veileder users not enabled in Microsoft Graph

### DIFF
--- a/src/main/kotlin/no/nav/syfo/client/graphapi/GraphApiClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/graphapi/GraphApiClient.kt
@@ -41,7 +41,7 @@ class GraphApiClient(
                 val queryFilter = "startsWith(onPremisesSamAccountName, '$veilederIdent')"
                 val queryFilterWhitespaceEncoded = queryFilter.replace(" ", "%20")
                 val url =
-                    "$baseUrl/v1.0/users?\$filter=$queryFilterWhitespaceEncoded&\$select=onPremisesSamAccountName,givenName,surname,mail,businessPhones&\$count=true"
+                    "$baseUrl/v1.0/users?\$filter=$queryFilterWhitespaceEncoded&\$select=onPremisesSamAccountName,givenName,surname,mail,businessPhones,accountEnabled&\$count=true"
 
                 val response: GraphApiGetUserResponse = httpClient.get(url) {
                     header(HttpHeaders.Authorization, bearerHeader(oboToken))
@@ -98,7 +98,7 @@ class GraphApiClient(
                 RequestEntry(
                     id = (index + 1).toString(),
                     method = "GET",
-                    url = "/users?\$filter=$query&\$select=onPremisesSamAccountName,givenName,surname,mail,businessPhones&\$count=true",
+                    url = "/users?\$filter=$query&\$select=onPremisesSamAccountName,givenName,surname,mail,businessPhones,accountEnabled&\$count=true",
                     headers = mapOf("ConsistencyLevel" to "eventual", "Content-Type" to "application/json")
                 )
             }

--- a/src/main/kotlin/no/nav/syfo/client/graphapi/GraphApiGetUserResponse.kt
+++ b/src/main/kotlin/no/nav/syfo/client/graphapi/GraphApiGetUserResponse.kt
@@ -8,6 +8,7 @@ data class GraphApiUser(
     val onPremisesSamAccountName: String,
     val mail: String?,
     val businessPhones: List<String>?,
+    val accountEnabled: Boolean?,
 )
 
 data class GraphApiGetUserResponse(

--- a/src/test/kotlin/no/nav/syfo/testhelper/mock/GraphApiMock.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/mock/GraphApiMock.kt
@@ -5,58 +5,57 @@ import io.ktor.client.request.*
 import io.ktor.http.*
 import no.nav.syfo.client.graphapi.*
 import no.nav.syfo.testhelper.UserConstants.VEILEDER_IDENT
+import no.nav.syfo.testhelper.UserConstants.VEILEDER_IDENT_2
 
-fun generateGraphapiUserResponse() =
-    GraphApiGetUserResponse(
-        value = listOf(
-            GraphApiUser(
-                givenName = "Given",
-                surname = "Surname",
-                onPremisesSamAccountName = VEILEDER_IDENT,
-                mail = "give.surname@nav.no",
-                businessPhones = emptyList(),
-            )
-        )
-    )
+val veilederUser = GraphApiUser(
+    givenName = "Given",
+    surname = "Surname",
+    onPremisesSamAccountName = VEILEDER_IDENT,
+    mail = "give.surname@nav.no",
+    businessPhones = emptyList(),
+    accountEnabled = true,
+)
+
+val veilederDisabledUser = veilederUser.copy(
+    accountEnabled = false,
+    onPremisesSamAccountName = VEILEDER_IDENT_2
+)
 
 fun generateGraphapiUserResponseEmpty() =
     GraphApiGetUserResponse(
         value = emptyList()
     )
 
-fun generateGraphapiUserListResponse() =
-    BatchResponse(
+fun generateGraphapiUserListResponse(): BatchResponse {
+    return BatchResponse(
         responses = listOf(
             BatchBody(
                 id = "1",
                 body = GetUsersResponse(
-                    value = listOf(
-                        GraphApiUser(
-                            givenName = "Given",
-                            surname = "Surname",
-                            onPremisesSamAccountName = VEILEDER_IDENT,
-                            mail = "give.surname@nav.no",
-                            businessPhones = emptyList(),
-                        ),
-                    ),
+                    value = listOf(veilederUser),
                 ),
             ),
         ),
     )
+}
 
-val graphapiUserResponse = generateGraphapiUserResponse()
-val graphapiUserResponseEmpty = generateGraphapiUserResponseEmpty()
-val graphapiUserListResponse = generateGraphapiUserListResponse()
+val graphapiUserResponse = GraphApiGetUserResponse(
+    value = listOf(veilederUser)
+)
+val graphapiDisabledUserResponse = GraphApiGetUserResponse(
+    value = listOf(veilederDisabledUser)
+)
 
 fun MockRequestHandleScope.graphApiMockResponse(request: HttpRequestData): HttpResponseData {
     return when (request.method) {
         HttpMethod.Get -> {
             val filter = request.url.parameters["\$filter"]!!
-            val response = if (filter.contains(VEILEDER_IDENT)) graphapiUserResponse else graphapiUserResponseEmpty
+            val response =
+                if (filter.contains(VEILEDER_IDENT)) graphapiUserResponse else if (filter.contains(VEILEDER_IDENT_2)) graphapiDisabledUserResponse else generateGraphapiUserResponseEmpty()
             respond(response)
         }
         HttpMethod.Post -> {
-            respond(graphapiUserListResponse)
+            respond(generateGraphapiUserListResponse())
         }
         else -> respondBadRequest()
     }

--- a/src/test/kotlin/no/nav/syfo/veileder/api/VeiledereApiSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/veileder/api/VeiledereApiSpek.kt
@@ -126,6 +126,23 @@ class VeiledereApiSpek : Spek({
                         veilederInfoDTO.epost shouldBeEqualTo graphapiUserResponse.mail
                     }
                 }
+
+                it("should return OK for veileder not enabled in graph api") {
+                    testApplication {
+                        val client = setupApiAndClient()
+                        val response = client.get("$basePath/${UserConstants.VEILEDER_IDENT_2}") {
+                            bearerAuth(validTokenVeileder2)
+                        }
+
+                        response.status shouldBeEqualTo HttpStatusCode.OK
+                        val veilederInfoDTO = response.body<VeilederInfo>()
+
+                        veilederInfoDTO.ident shouldBeEqualTo UserConstants.VEILEDER_IDENT_2
+                        veilederInfoDTO.fornavn shouldBeEqualTo graphapiUserResponse.givenName
+                        veilederInfoDTO.etternavn shouldBeEqualTo graphapiUserResponse.surname
+                        veilederInfoDTO.epost shouldBeEqualTo graphapiUserResponse.mail
+                    }
+                }
             }
             describe("Unhappy paths") {
                 it("should return status Unauthorized if no token is supplied") {


### PR DESCRIPTION
Henter et ektra felt (`accountEnabled`) når vi slår opp veiledere(e) i Microsoft Graph og logger de som ikke er enabled.
Fra før logger vi veileder(e) som ikke finnes i Microsoft Graph.
I følge https://nav-it.slack.com/archives/CDKEM1HC5/p1732887746241329 kan dette muligens brukes til å fjerne knytning mellom veileder og sykmeldt i oversikten så tenkte begynne med å logge her for å finne ut av omfanget.