### PR TITLE
IS-2260: Add enabled field to dto

### DIFF
--- a/src/main/kotlin/no/nav/syfo/client/graphapi/GraphApiGetUserResponse.kt
+++ b/src/main/kotlin/no/nav/syfo/client/graphapi/GraphApiGetUserResponse.kt
@@ -8,7 +8,7 @@ data class GraphApiUser(
     val onPremisesSamAccountName: String,
     val mail: String?,
     val businessPhones: List<String>?,
-    val accountEnabled: Boolean?,
+    val accountEnabled: Boolean,
 )
 
 data class GraphApiGetUserResponse(
@@ -22,4 +22,5 @@ fun GraphApiUser.toVeilederInfo(veilederIdent: String) =
         etternavn = this.surname,
         epost = this.mail ?: "",
         telefonnummer = this.businessPhones?.firstOrNull(),
+        enabled = this.accountEnabled,
     )

--- a/src/main/kotlin/no/nav/syfo/veileder/GraphApiException.kt
+++ b/src/main/kotlin/no/nav/syfo/veileder/GraphApiException.kt
@@ -1,3 +1,0 @@
-package no.nav.syfo.veileder
-
-class GraphApiException(message: String = "Request to Microsoft Graph API failed") : RuntimeException(message)

--- a/src/main/kotlin/no/nav/syfo/veileder/VeilederInfo.kt
+++ b/src/main/kotlin/no/nav/syfo/veileder/VeilederInfo.kt
@@ -6,4 +6,5 @@ data class VeilederInfo(
     val etternavn: String,
     val epost: String,
     val telefonnummer: String? = null,
+    val enabled: Boolean? = null,
 )

--- a/src/main/kotlin/no/nav/syfo/veileder/api/VeiledereApi.kt
+++ b/src/main/kotlin/no/nav/syfo/veileder/api/VeiledereApi.kt
@@ -1,7 +1,6 @@
 package no.nav.syfo.veileder.api
 
 import io.ktor.http.*
-import io.ktor.server.application.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import no.nav.syfo.application.api.authentication.getNAVIdentFromToken
@@ -54,15 +53,13 @@ fun Route.registrerVeiledereApi(
                     token = token,
                     veilederIdent = veilederIdent,
                 )
-                call.respond<VeilederInfo>(veilederinfo)
+                veilederinfo?.let {
+                    call.respond<VeilederInfo>(it)
+                } ?: call.respond(HttpStatusCode.NotFound, "User was not found in Microsoft Graph for ident $veilederIdent")
             } catch (e: IllegalArgumentException) {
                 val illegalArgumentMessage = "Could not retrieve Veilederinfo for self"
                 log.warn("$illegalArgumentMessage: {}, {}", e.message, callId)
                 call.respond(HttpStatusCode.BadRequest, e.message ?: illegalArgumentMessage)
-            } catch (e: GraphApiException) {
-                val warningMessage = "Could not retrieve Veilederinfo for self"
-                log.warn("$warningMessage: {}, {}", e.message, callId)
-                call.respond(HttpStatusCode.InternalServerError, e.message ?: warningMessage)
             }
         }
 
@@ -80,15 +77,13 @@ fun Route.registrerVeiledereApi(
                     veilederIdent = veilederIdent,
                     token = token,
                 )
-                call.respond<VeilederInfo>(veilederinfo)
+                veilederinfo?.let {
+                    call.respond<VeilederInfo>(it)
+                } ?: call.respond(HttpStatusCode.NotFound, "User was not found in Microsoft Graph for ident $veilederIdent")
             } catch (e: IllegalArgumentException) {
                 val illegalArgumentMessage = "Could not retrieve Veilederinfo for NavIdent"
                 log.warn("$illegalArgumentMessage: {}, {}", e.message, callId)
                 call.respond(HttpStatusCode.BadRequest, e.message ?: illegalArgumentMessage)
-            } catch (e: GraphApiException) {
-                val warningMessage = "Could not retrieve Veilederinfo for NavIdent"
-                log.warn("$warningMessage: {}, {}", e.message, callId)
-                call.respond(HttpStatusCode.InternalServerError, e.message ?: warningMessage)
             }
         }
     }

--- a/src/main/kotlin/no/nav/syfo/veiledernavn/VeilederService.kt
+++ b/src/main/kotlin/no/nav/syfo/veiledernavn/VeilederService.kt
@@ -14,7 +14,7 @@ class VeilederService(
         callId: String,
         token: String,
         veilederIdent: String,
-    ): VeilederInfo {
+    ): VeilederInfo? {
         val graphApiUser = graphApiClient.veileder(
             callId = callId,
             token = token,
@@ -24,7 +24,6 @@ class VeilederService(
             log.warn("Veileder with ident $veilederIdent is not enabled in Microsoft Graph")
         }
         return graphApiUser?.toVeilederInfo(veilederIdent)
-            ?: throw GraphApiException("User was not found in Microsoft Graph for ident $veilederIdent")
     }
 
     suspend fun getVeiledere(
@@ -43,7 +42,7 @@ class VeilederService(
             callId = callId,
             token = token,
         )
-        val usersNotEnabled = graphApiUsers.filter { it.accountEnabled == false }.map { it.onPremisesSamAccountName }
+        val usersNotEnabled = graphApiUsers.filter { !it.accountEnabled }.map { it.onPremisesSamAccountName }
         if (usersNotEnabled.isNotEmpty()) {
             log.warn("Fant ${usersNotEnabled.size} veiledere i Microsoft Graph som er disabled. Identer: ${usersNotEnabled.joinToString()}")
         }

--- a/src/test/kotlin/no/nav/syfo/veileder/api/VeiledereApiSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/veileder/api/VeiledereApiSpek.kt
@@ -16,8 +16,7 @@ import no.nav.syfo.testhelper.mock.generateAxsysResponse
 import no.nav.syfo.testhelper.mock.graphapiUserResponse
 import no.nav.syfo.util.configure
 import no.nav.syfo.veileder.VeilederInfo
-import org.amshove.kluent.shouldBeEqualTo
-import org.amshove.kluent.shouldNotBeEqualTo
+import org.amshove.kluent.*
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
@@ -81,6 +80,7 @@ class VeiledereApiSpek : Spek({
                         veilederInfo.fornavn shouldBeEqualTo graphapiUserResponse.givenName
                         veilederInfo.etternavn shouldBeEqualTo graphapiUserResponse.surname
                         veilederInfo.epost shouldBeEqualTo graphapiUserResponse.mail
+                        veilederInfo.enabled shouldBeEqualTo true
                         redisCache.getObject<GraphApiUser>(cacheKey) shouldNotBeEqualTo null
                     }
                 }
@@ -124,6 +124,7 @@ class VeiledereApiSpek : Spek({
                         veilederInfoDTO.fornavn shouldBeEqualTo graphapiUserResponse.givenName
                         veilederInfoDTO.etternavn shouldBeEqualTo graphapiUserResponse.surname
                         veilederInfoDTO.epost shouldBeEqualTo graphapiUserResponse.mail
+                        veilederInfoDTO.enabled shouldBeEqualTo true
                     }
                 }
 
@@ -141,6 +142,7 @@ class VeiledereApiSpek : Spek({
                         veilederInfoDTO.fornavn shouldBeEqualTo graphapiUserResponse.givenName
                         veilederInfoDTO.etternavn shouldBeEqualTo graphapiUserResponse.surname
                         veilederInfoDTO.epost shouldBeEqualTo graphapiUserResponse.mail
+                        veilederInfoDTO.enabled shouldBeEqualTo false
                     }
                 }
             }
@@ -189,10 +191,12 @@ class VeiledereApiSpek : Spek({
                         veilederInfoList.first().ident shouldBeEqualTo axsysResponse.first().appIdent
                         veilederInfoList.first().fornavn shouldBeEqualTo graphapiUserResponse.givenName
                         veilederInfoList.first().etternavn shouldBeEqualTo graphapiUserResponse.surname
+                        veilederInfoList.first().enabled shouldBeEqualTo true
 
                         veilederInfoList.last().ident shouldBeEqualTo axsysResponse.last().appIdent
                         veilederInfoList.last().fornavn shouldBeEqualTo ""
                         veilederInfoList.last().etternavn shouldBeEqualTo ""
+                        veilederInfoList.last().enabled.shouldBeNull()
                         redisCache.getListObject<AxsysVeileder>(cacheKey) shouldNotBeEqualTo null
                     }
                 }


### PR DESCRIPTION
Legger til `enabled`-felt på `VeilederInfo`-dtoen (hentet fra `accountEnabled`-feltet i MS Graph). 
Tenker det er best å fortsatt returnere veiledere som ikke finnes/er aktive i MS Graph i `/veiledere`-apiet sånn at de kan gjenfinne personer i oversikten som er fordelt på veiledere som har sluttet ("Søk veileder" i oversikten). 
Men vi kan bruke `enabled`-feltet i "Tildel veileder" i frontend til å skjule veiledere som ikke finnes/er aktive.