### PR TITLE
IS-2260: Add veileder system api

### DIFF
--- a/.nais/naiserator-dev.yaml
+++ b/.nais/naiserator-dev.yaml
@@ -46,14 +46,9 @@ spec:
     inbound:
       rules:
         - application: syfomodiaperson
-          namespace: teamsykefravr
-          cluster: dev-gcp
         - application: syfomoteoversikt
-          namespace: teamsykefravr
-          cluster: dev-gcp
         - application: syfooversikt
-          namespace: teamsykefravr
-          cluster: dev-gcp
+        - application: syfooversiktsrv
     outbound:
       external:
         - host: "graph.microsoft.com"

--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -46,14 +46,9 @@ spec:
     inbound:
       rules:
         - application: syfomodiaperson
-          namespace: teamsykefravr
-          cluster: prod-gcp
         - application: syfomoteoversikt
-          namespace: teamsykefravr
-          cluster: prod-gcp
         - application: syfooversikt
-          namespace: teamsykefravr
-          cluster: prod-gcp
+        - application: syfooversiktsrv
     outbound:
       external:
         - host: "graph.microsoft.com"

--- a/src/main/kotlin/no/nav/syfo/application/ApplicationEnvironment.kt
+++ b/src/main/kotlin/no/nav/syfo/application/ApplicationEnvironment.kt
@@ -1,7 +1,8 @@
 package no.nav.syfo.application
 
-import io.ktor.server.application.*
+import com.fasterxml.jackson.module.kotlin.readValue
 import no.nav.syfo.application.cache.RedisConfig
+import no.nav.syfo.util.configuredJacksonMapper
 import java.net.URI
 
 data class Environment(
@@ -9,6 +10,7 @@ data class Environment(
     val azureAppClientSecret: String = getEnvVar("AZURE_APP_CLIENT_SECRET"),
     val azureAppWellKnownUrl: String = getEnvVar("AZURE_APP_WELL_KNOWN_URL"),
     val azureOpenidConfigTokenEndpoint: String = getEnvVar("AZURE_OPENID_CONFIG_TOKEN_ENDPOINT"),
+    val preAuthorizedApps: List<PreAuthorizedApp> = configuredJacksonMapper().readValue(getEnvVar("AZURE_APP_PRE_AUTHORIZED_APPS")),
 
     val axsysClientId: String = getEnvVar("AXSYS_CLIENT_ID"),
     val axsysUrl: String = getEnvVar("AXSYS_URL"),
@@ -24,12 +26,12 @@ data class Environment(
 fun getEnvVar(varName: String, defaultValue: String? = null) =
     System.getenv(varName) ?: defaultValue ?: throw RuntimeException("Missing required variable \"$varName\"")
 
-val Application.envKind get() = environment.config.property("ktor.environment").getString()
-
-fun Application.isDev(block: () -> Unit) {
-    if (envKind == "dev") block()
-}
-
-fun Application.isProd(block: () -> Unit) {
-    if (envKind == "production") block()
+data class PreAuthorizedApp(
+    val name: String,
+    val clientId: String
+) {
+    fun getAppnavn(): String {
+        val split = name.split(":")
+        return split[2]
+    }
 }

--- a/src/main/kotlin/no/nav/syfo/application/api/ApiModule.kt
+++ b/src/main/kotlin/no/nav/syfo/application/api/ApiModule.kt
@@ -9,6 +9,7 @@ import no.nav.syfo.application.api.authentication.JwtIssuer
 import no.nav.syfo.application.api.authentication.JwtIssuerType
 import no.nav.syfo.application.api.authentication.installJwtAuthentication
 import no.nav.syfo.client.wellknown.WellKnown
+import no.nav.syfo.veileder.api.registrerVeilederSystemApi
 import no.nav.syfo.veileder.api.registrerVeiledereApi
 import no.nav.syfo.veiledernavn.VeilederService
 
@@ -39,6 +40,7 @@ fun Application.apiModule(
         registerPrometheusApi()
         authenticate(JwtIssuerType.INTERNAL_AZUREAD.name) {
             registrerVeiledereApi(veilederService = veilederService)
+            registrerVeilederSystemApi(veilederService = veilederService, preAuthorizedApps = environment.preAuthorizedApps)
         }
     }
 }

--- a/src/main/kotlin/no/nav/syfo/client/azuread/AzureAdClientMetric.kt
+++ b/src/main/kotlin/no/nav/syfo/client/azuread/AzureAdClientMetric.kt
@@ -11,10 +11,22 @@ const val CALL_AZUREAD_TOKEN_OBO_BASE = "${CALL_AZUREAD_BASE}_token_obo"
 const val CALL_AZUREAD_TOKEN_OBO_CACHE_HIT = "${CALL_AZUREAD_TOKEN_OBO_BASE}_cache_hit_count"
 const val CALL_AZUREAD_TOKEN_OBO_CACHE_MISS = "${CALL_AZUREAD_TOKEN_OBO_BASE}_cache_miss_count"
 
+const val CALL_AZUREAD_TOKEN_SYSTEM_BASE = "${CALL_AZUREAD_BASE}_token_system"
+const val CALL_AZUREAD_TOKEN_SYSTEM_CACHE_HIT = "${CALL_AZUREAD_TOKEN_SYSTEM_BASE}_cache_hit_count"
+const val CALL_AZUREAD_TOKEN_SYSTEM_CACHE_MISS = "${CALL_AZUREAD_TOKEN_SYSTEM_BASE}_cache_miss_count"
+
 val COUNT_CALL_AZUREAD_TOKEN_OBO_CACHE_HIT: Counter = builder(CALL_AZUREAD_TOKEN_OBO_CACHE_HIT)
     .description("Counts the number of cache hits for calls to AzureAd - OBO token")
     .register(METRICS_REGISTRY)
 
 val COUNT_CALL_AZUREAD_TOKEN_OBO_CACHE_MISS: Counter = builder(CALL_AZUREAD_TOKEN_OBO_CACHE_MISS)
     .description("Counts the number of cache misses for calls to AzureAd - OBO token")
+    .register(METRICS_REGISTRY)
+
+val COUNT_CALL_AZUREAD_TOKEN_SYSTEM_CACHE_HIT: Counter = builder(CALL_AZUREAD_TOKEN_SYSTEM_CACHE_HIT)
+    .description("Counts the number of cache hits for calls to AzureAd - system token")
+    .register(METRICS_REGISTRY)
+
+val COUNT_CALL_AZUREAD_TOKEN_SYSTEM_CACHE_MISS: Counter = builder(CALL_AZUREAD_TOKEN_SYSTEM_CACHE_MISS)
+    .description("Counts the number of cache misses for calls to AzureAd - system token")
     .register(METRICS_REGISTRY)

--- a/src/main/kotlin/no/nav/syfo/util/PipelineUtil.kt
+++ b/src/main/kotlin/no/nav/syfo/util/PipelineUtil.kt
@@ -3,7 +3,6 @@ package no.nav.syfo.util
 import io.ktor.http.*
 import io.ktor.server.application.*
 import io.ktor.server.routing.*
-import io.ktor.util.pipeline.*
 
 fun RoutingContext.getBearerHeader(): String? {
     return this.call.request.headers[HttpHeaders.Authorization]?.removePrefix("Bearer ")

--- a/src/main/kotlin/no/nav/syfo/veileder/api/VeilederSystemApi.kt
+++ b/src/main/kotlin/no/nav/syfo/veileder/api/VeilederSystemApi.kt
@@ -1,0 +1,56 @@
+package no.nav.syfo.veileder.api
+
+import io.ktor.http.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import no.nav.syfo.application.PreAuthorizedApp
+import no.nav.syfo.application.api.authentication.getConsumerClientId
+import no.nav.syfo.util.getBearerHeader
+import no.nav.syfo.util.getCallId
+import no.nav.syfo.veileder.VeilederInfo
+import no.nav.syfo.veiledernavn.VeilederService
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+private val log: Logger = LoggerFactory.getLogger("no.nav.syfo")
+
+const val systemApiBasePath = "/syfoveileder/api/system"
+private val veilederSystemApiAuthorizedApps = listOf("syfooversiktsrv")
+
+fun Route.registrerVeilederSystemApi(
+    veilederService: VeilederService,
+    preAuthorizedApps: List<PreAuthorizedApp>,
+) {
+    route(systemApiBasePath) {
+        get("/veiledere/{navIdent}") {
+            val callId = getCallId()
+            try {
+                val token = getBearerHeader()
+                    ?: throw IllegalArgumentException("No Authorization header supplied")
+                val consumerClientId = getConsumerClientId(token)
+                val veilederSystemApiAuthorizedClientIds = preAuthorizedApps
+                    .filter { veilederSystemApiAuthorizedApps.contains(it.getAppnavn()) }
+                    .map { it.clientId }
+                if (!veilederSystemApiAuthorizedClientIds.contains(consumerClientId)) {
+                    call.respond(HttpStatusCode.Forbidden, "Consumer with clientId(azp)=$consumerClientId is denied access to system API")
+                } else {
+                    val veilederIdent = call.parameters["navIdent"]
+                        ?: throw IllegalArgumentException("No VeilederIdent found in path param")
+
+                    val veilederinfo = veilederService.veilederInfoMedSystemToken(
+                        callId = callId,
+                        token = token,
+                        veilederIdent = veilederIdent,
+                    )
+                    veilederinfo?.let {
+                        call.respond<VeilederInfo>(it)
+                    } ?: call.respond(HttpStatusCode.NotFound, "User was not found in Microsoft Graph for ident $veilederIdent")
+                }
+            } catch (e: IllegalArgumentException) {
+                val illegalArgumentMessage = "Could not retrieve Veilederinfo for NavIdent"
+                log.warn("$illegalArgumentMessage: {}, {}", e.message, callId)
+                call.respond(HttpStatusCode.BadRequest, e.message ?: illegalArgumentMessage)
+            }
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/syfo/veiledernavn/VeilederService.kt
+++ b/src/main/kotlin/no/nav/syfo/veiledernavn/VeilederService.kt
@@ -26,6 +26,16 @@ class VeilederService(
         return graphApiUser?.toVeilederInfo(veilederIdent)
     }
 
+    suspend fun veilederInfoMedSystemToken(
+        callId: String,
+        token: String,
+        veilederIdent: String,
+    ): VeilederInfo? = graphApiClient.veilederMedSystemToken(
+        callId = callId,
+        token = token,
+        veilederIdent = veilederIdent,
+    )?.toVeilederInfo(veilederIdent)
+
     suspend fun getVeiledere(
         callId: String,
         enhetNr: String,

--- a/src/test/kotlin/no/nav/syfo/testhelper/JWTUtils.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/JWTUtils.kt
@@ -24,6 +24,7 @@ fun generateJWT(
     issuer: String,
     navIdent: String? = null,
     subject: String? = null,
+    azp: String? = UserConstants.JWT_AZP,
     expiry: LocalDateTime? = LocalDateTime.now().plusHours(1)
 ): String {
     val now = Date()
@@ -42,7 +43,7 @@ fun generateJWT(
         .withClaim("nbf", now)
         .withClaim("iat", now)
         .withClaim("exp", Date.from(expiry?.atZone(ZoneId.systemDefault())?.toInstant()))
-        .withClaim(JWT_CLAIM_AZP, UserConstants.JWT_AZP)
+        .withClaim(JWT_CLAIM_AZP, azp)
         .withClaim(JWT_CLAIM_NAVIDENT, navIdent)
         .sign(alg)
 }

--- a/src/test/kotlin/no/nav/syfo/testhelper/TestEnvironment.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/TestEnvironment.kt
@@ -2,6 +2,7 @@ package no.nav.syfo.testhelper
 
 import no.nav.syfo.application.ApplicationState
 import no.nav.syfo.application.Environment
+import no.nav.syfo.application.PreAuthorizedApp
 import no.nav.syfo.application.cache.RedisConfig
 import java.net.URI
 
@@ -10,6 +11,7 @@ fun testEnvironment() = Environment(
     azureAppClientSecret = "isdialogmote-secret",
     azureAppWellKnownUrl = "wellknown",
     azureOpenidConfigTokenEndpoint = "azureOpenIdTokenEndpoint",
+    preAuthorizedApps = testAzureAppPreAuthorizedApps,
     axsysClientId = "dev-fss.org.axsys",
     axsysUrl = "axsysUrl",
     graphapiUrl = "graphapiUrl",
@@ -25,4 +27,14 @@ fun testEnvironment() = Environment(
 fun testAppState() = ApplicationState(
     alive = true,
     ready = true,
+)
+
+private const val syfooversiktsrvApplicationName: String = "syfooversiktsrv"
+const val syfooversiktsrvClientId = "$syfooversiktsrvApplicationName-client-id"
+
+val testAzureAppPreAuthorizedApps = listOf(
+    PreAuthorizedApp(
+        name = "cluster:teamsykefravr:$syfooversiktsrvApplicationName",
+        clientId = syfooversiktsrvClientId,
+    )
 )

--- a/src/test/kotlin/no/nav/syfo/veileder/api/VeiledereSystemApiSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/veileder/api/VeiledereSystemApiSpek.kt
@@ -1,0 +1,90 @@
+package no.nav.syfo.veileder.api
+
+import io.ktor.client.*
+import io.ktor.client.call.*
+import io.ktor.client.plugins.contentnegotiation.*
+import io.ktor.client.request.*
+import io.ktor.http.*
+import io.ktor.serialization.jackson.*
+import io.ktor.server.testing.*
+import no.nav.syfo.testhelper.*
+import no.nav.syfo.testhelper.mock.veilederUser
+import no.nav.syfo.util.configure
+import no.nav.syfo.veileder.VeilederInfo
+import org.amshove.kluent.*
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+class VeiledereSystemApiSpek : Spek({
+    describe(VeiledereSystemApiSpek::class.java.simpleName) {
+
+        val externalMockEnvironment = ExternalMockEnvironment()
+
+        fun ApplicationTestBuilder.setupApiAndClient(): HttpClient {
+            application {
+                testApiModule(
+                    externalMockEnvironment = externalMockEnvironment,
+                )
+            }
+            val client = createClient {
+                install(ContentNegotiation) {
+                    jackson { configure() }
+                }
+            }
+
+            return client
+        }
+
+        beforeGroup {
+            externalMockEnvironment.startExternalMocks()
+        }
+
+        afterGroup {
+            externalMockEnvironment.stopExternalMocks()
+        }
+
+        describe("Get Veilederinfo") {
+            val apiUrl = "$systemApiBasePath/veiledere/${UserConstants.VEILEDER_IDENT}"
+            val validSystemToken = generateJWT(
+                audience = externalMockEnvironment.environment.azureAppClientId,
+                issuer = externalMockEnvironment.wellKnownInternalAzureAD.issuer,
+                azp = syfooversiktsrvClientId,
+            )
+
+            it("Returns OK if request is successful") {
+                testApplication {
+                    val client = setupApiAndClient()
+                    val response = client.get(apiUrl) {
+                        bearerAuth(validSystemToken)
+                    }
+
+                    response.status shouldBeEqualTo HttpStatusCode.OK
+                    val veilederInfo = response.body<VeilederInfo>()
+
+                    veilederInfo.ident shouldBeEqualTo UserConstants.VEILEDER_IDENT
+                    veilederInfo.fornavn shouldBeEqualTo veilederUser.givenName
+                    veilederInfo.etternavn shouldBeEqualTo veilederUser.surname
+                    veilederInfo.epost shouldBeEqualTo veilederUser.mail
+                    veilederInfo.enabled shouldBeEqualTo true
+                }
+            }
+
+            it("Returns status Forbidden when wrong consumer azp") {
+                val invalidValidSystemToken = generateJWT(
+                    audience = externalMockEnvironment.environment.azureAppClientId,
+                    issuer = externalMockEnvironment.wellKnownInternalAzureAD.issuer,
+                    azp = "invalid_azp",
+                )
+
+                testApplication {
+                    val client = setupApiAndClient()
+                    val response = client.get(apiUrl) {
+                        bearerAuth(invalidValidSystemToken)
+                    }
+
+                    response.status shouldBeEqualTo HttpStatusCode.Forbidden
+                }
+            }
+        }
+    }
+})


### PR DESCRIPTION
Legger til rette for at `syfooversiktsrv` kan kalle api her for å sjekke om veileder er enabled/finnes. Opplegg for system-api er basert på sånn vi har satt det opp i andre apper. Siden `syfooversiktsrv` må gjøre dette fra en jobb eller consumer og ikke api-kall fra veileder så trenger vi å bruke system-token her.
For å kunne kalle MS Graph apiet med system-token måtte jeg også be azure-gjengen om ekstra tilgang for syfoveileder: https://nav-it.slack.com/archives/C0190RZ6HB4/p1738226381620449