### PR TITLE
IS-3269: Endret base name for telling av gruppe

### DIFF
--- a/src/main/kotlin/no/nav/syfo/client/graphapi/GraphApiMetric.kt
+++ b/src/main/kotlin/no/nav/syfo/client/graphapi/GraphApiMetric.kt
@@ -29,7 +29,7 @@ val COUNT_CALL_GRAPHAPI_VEILEDER_CACHE_MISS: Counter = Counter
     .description("Counts the number of cache miss GraphAPI - Veileder")
     .register(METRICS_REGISTRY)
 
-const val CALL_MS_GRAPH_API_GRUPPE_BASE = "${CALL_GRAPHAPI_BASE}_GRUPPE"
+const val CALL_MS_GRAPH_API_GRUPPE_BASE = "${CALL_GRAPHAPI_BASE}_gruppe"
 const val CALL_MS_GRAPH_API_GRUPPE_SUCCESS = "${CALL_MS_GRAPH_API_GRUPPE_BASE}_success_count"
 const val CALL_MS_GRAPH_API_GRUPPE_FAIL = "${CALL_MS_GRAPH_API_GRUPPE_BASE}_fail_count"
 const val CALL_MS_GRAPH_API_GRUPPE_CACHE_HIT = "${CALL_MS_GRAPH_API_GRUPPE_BASE}_cache_hit"


### PR DESCRIPTION
Dette ble introdusert i forrige [PR](https://github.com/navikt/syfoveileder/pull/132/files#diff-f3ce094705a6ea16a7b46a61e5bc821b087a9fb4698cfeec6abc798af929600bR32) ifm. avvikling av Axsys. Det var ikke intensjonelt at den var upper case, så endrer den til lower så er det er likt som andre steder.

Antar dette ikke har noe mer betydning enn at data på den forrige blir borte. 