### PR TITLE
Fjernet henting av e-post og telefonnummer ettersom det ikke brukes

### DIFF
--- a/src/main/kotlin/no/nav/syfo/client/graphapi/GraphApiClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/graphapi/GraphApiClient.kt
@@ -78,7 +78,7 @@ class GraphApiClient(
         val queryFilter = "startsWith(onPremisesSamAccountName, '$veilederIdent')"
         val queryFilterWhitespaceEncoded = queryFilter.replace(" ", "%20")
         val url =
-            "$baseUrl/v1.0/users?\$filter=$queryFilterWhitespaceEncoded&\$select=onPremisesSamAccountName,givenName,surname,mail,businessPhones,accountEnabled&\$count=true"
+            "$baseUrl/v1.0/users?\$filter=$queryFilterWhitespaceEncoded&\$select=onPremisesSamAccountName,givenName,surname,accountEnabled&\$count=true"
 
         val response: GraphApiGetUserResponse = httpClient.get(url) {
             header(HttpHeaders.Authorization, bearerHeader(token))
@@ -236,8 +236,6 @@ class GraphApiClient(
                     arrayOf(
                         "givenName",
                         "surname",
-                        "mail",
-                        "businessPhones",
                         "onPremisesSamAccountName",
                         "accountEnabled"
                     )
@@ -262,8 +260,6 @@ class GraphApiClient(
             ident = this.onPremisesSamAccountName,
             fornavn = this.givenName ?: "",
             etternavn = this.surname ?: "",
-            epost = this.mail ?: "",
-            telefonnummer = this.businessPhones?.firstOrNull(),
             enabled = this.accountEnabled,
         )
     }

--- a/src/main/kotlin/no/nav/syfo/client/graphapi/GraphApiGetUserResponse.kt
+++ b/src/main/kotlin/no/nav/syfo/client/graphapi/GraphApiGetUserResponse.kt
@@ -6,8 +6,6 @@ data class GraphApiUser(
     val givenName: String,
     val surname: String,
     val onPremisesSamAccountName: String,
-    val mail: String?,
-    val businessPhones: List<String>?,
     val accountEnabled: Boolean,
 )
 
@@ -20,7 +18,5 @@ fun GraphApiUser.toVeilederInfo(veilederIdent: String) =
         ident = veilederIdent,
         fornavn = this.givenName,
         etternavn = this.surname,
-        epost = this.mail ?: "",
-        telefonnummer = this.businessPhones?.firstOrNull(),
         enabled = this.accountEnabled,
     )

--- a/src/main/kotlin/no/nav/syfo/veileder/VeilederInfo.kt
+++ b/src/main/kotlin/no/nav/syfo/veileder/VeilederInfo.kt
@@ -4,8 +4,6 @@ data class VeilederInfo(
     val ident: String,
     val fornavn: String,
     val etternavn: String,
-    val epost: String,
-    val telefonnummer: String? = null,
     val enabled: Boolean? = null,
 )
 

--- a/src/test/kotlin/no/nav/syfo/testhelper/mock/GraphApiMock.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/mock/GraphApiMock.kt
@@ -15,8 +15,6 @@ val veilederUser = GraphApiUser(
     givenName = "Given",
     surname = "Surname",
     onPremisesSamAccountName = VEILEDER_IDENT,
-    mail = "give.surname@nav.no",
-    businessPhones = emptyList(),
     accountEnabled = true,
 )
 
@@ -72,8 +70,6 @@ fun user(): User {
     user.givenName = "Given"
     user.surname = "Surname"
     user.onPremisesSamAccountName = VEILEDER_IDENT
-    user.mail = "given.surname@nav.no"
-    user.businessPhones = listOf("00 00 00 00")
     user.accountEnabled = true
     return user
 }
@@ -83,8 +79,6 @@ fun userWithNullFields(): User {
     user.givenName = null
     user.surname = null
     user.onPremisesSamAccountName = null
-    user.mail = null
-    user.businessPhones = emptyList()
     user.accountEnabled = false
     return user
 }

--- a/src/test/kotlin/no/nav/syfo/veileder/api/VeiledereApiTest.kt
+++ b/src/test/kotlin/no/nav/syfo/veileder/api/VeiledereApiTest.kt
@@ -113,7 +113,6 @@ class VeiledereApiTest {
                     assertEquals(UserConstants.VEILEDER_IDENT, veilederInfo.ident)
                     assertEquals(graphapiUserResponse.givenName, veilederInfo.fornavn)
                     assertEquals(graphapiUserResponse.surname, veilederInfo.etternavn)
-                    assertEquals(graphapiUserResponse.mail, veilederInfo.epost)
                     assertTrue(veilederInfo.enabled!!)
                     assertNotNull(valkeyCache.getObject<GraphApiUser>(cacheKey))
                 }
@@ -166,7 +165,6 @@ class VeiledereApiTest {
                     assertEquals(UserConstants.VEILEDER_IDENT, veilederInfoDTO.ident)
                     assertEquals(graphapiUserResponse.givenName, veilederInfoDTO.fornavn)
                     assertEquals(graphapiUserResponse.surname, veilederInfoDTO.etternavn)
-                    assertEquals(graphapiUserResponse.mail, veilederInfoDTO.epost)
                     assertTrue(veilederInfoDTO.enabled!!)
                 }
             }
@@ -185,7 +183,6 @@ class VeiledereApiTest {
                     assertEquals(UserConstants.VEILEDER_IDENT_2, veilederInfoDTO.ident)
                     assertEquals(graphapiUserResponse.givenName, veilederInfoDTO.fornavn)
                     assertEquals(graphapiUserResponse.surname, veilederInfoDTO.etternavn)
-                    assertEquals(graphapiUserResponse.mail, veilederInfoDTO.epost)
                     assertFalse(veilederInfoDTO.enabled!!)
                 }
             }
@@ -315,8 +312,6 @@ class VeiledereApiTest {
             assertEquals(UserConstants.VEILEDER_IDENT, veileder.ident)
             assertEquals("Given", veileder.fornavn)
             assertEquals("Surname", veileder.etternavn)
-            assertEquals("given.surname@nav.no", veileder.epost)
-            assertEquals("00 00 00 00", veileder.telefonnummer)
             assertTrue(veileder.enabled!!)
 
             val cachedGrupper = valkeyCache.getListObject<Gruppe>(gruppeCacheKey)!!
@@ -360,8 +355,6 @@ class VeiledereApiTest {
             assertEquals(UserConstants.VEILEDER_IDENT, veileder.ident)
             assertEquals("Given", veileder.fornavn)
             assertEquals("Surname", veileder.etternavn)
-            assertEquals("given.surname@nav.no", veileder.epost)
-            assertEquals("00 00 00 00", veileder.telefonnummer)
             assertTrue(veileder.enabled!!)
 
             val cachedGrupper = valkeyCache.getListObject<Gruppe>(gruppeCacheKey)!!

--- a/src/test/kotlin/no/nav/syfo/veileder/api/VeiledereSystemApiTest.kt
+++ b/src/test/kotlin/no/nav/syfo/veileder/api/VeiledereSystemApiTest.kt
@@ -70,7 +70,6 @@ class VeiledereSystemApiTest {
                 assertEquals(UserConstants.VEILEDER_IDENT, veilederInfo.ident)
                 assertEquals(veilederUser.givenName, veilederInfo.fornavn)
                 assertEquals(veilederUser.surname, veilederInfo.etternavn)
-                assertEquals(veilederUser.mail, veilederInfo.epost)
                 assertTrue(veilederInfo.enabled!!)
             }
         }


### PR DESCRIPTION
Fjerner henting av e-post og telefonnummer for veileder siden det ikke brukes. Bruken er fjernet fra apper som hadde referanser til disse feltene:
- https://github.com/navikt/syfomoteoversikt/pull/283
- https://github.com/navikt/syfooversikt/pull/673
- https://github.com/navikt/syfomodiaperson/pull/1796