### PR TITLE
IS: Increase daemon so codeql action succeeds

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+kotlin.code.style=official
+kotlin.daemon.jvmargs=-Xmx1024m


### PR DESCRIPTION
Denne feiler: https://github.com/navikt/syfoveileder/actions/runs/25125874700/job/73640152900

`Not enough memory to run compilation. Try to increase it via 'gradle.properties':
  [2026-04-29 18:24:54] [autobuild]      kotlin.daemon.jvmargs=-Xmx<size>`
